### PR TITLE
fix: `this` context type error

### DIFF
--- a/servers/all/$server.ts
+++ b/servers/all/$server.ts
@@ -178,8 +178,8 @@ const parseBooleanTypeQueryParams = (booleanTypeParams: [string, boolean, boolea
 }
 
 // prettier-ignore
-const callParserIfExistsQuery = (parser: preValidationHookHandler): preValidationHookHandler => (req, reply, done) =>
-  Object.keys(req.query as any).length ? parser(req, reply, done) : done()
+const callParserIfExistsQuery = (fastify: FastifyInstance, parser: preValidationHookHandler): preValidationHookHandler => (req, reply, done) =>
+  Object.keys(req.query as any).length ? parser.bind(fastify)(req, reply, done) : done()
 
 // prettier-ignore
 const normalizeQuery: preValidationHookHandler = (req, _, done) => {
@@ -288,8 +288,8 @@ export default (fastify: FastifyInstance, options: FrourioOptions = {}) => {
       onRequest: [...hooks0.onRequest, ctrlHooks0.onRequest],
       preParsing: hooks0.preParsing,
       preValidation: [
-        callParserIfExistsQuery(parseNumberTypeQueryParams([['requiredNum', false, false], ['optionalNum', true, false], ['optionalNumArr', true, true], ['emptyNum', true, false], ['requiredNumArr', false, true]])),
-        callParserIfExistsQuery(parseBooleanTypeQueryParams([['bool', false, false], ['optionalBool', true, false], ['boolArray', false, true], ['optionalBoolArray', true, true]])),
+        callParserIfExistsQuery(fastify, parseNumberTypeQueryParams([['requiredNum', false, false], ['optionalNum', true, false], ['optionalNumArr', true, true], ['emptyNum', true, false], ['requiredNumArr', false, true]])),
+        callParserIfExistsQuery(fastify, parseBooleanTypeQueryParams([['bool', false, false], ['optionalBool', true, false], ['boolArray', false, true], ['optionalBoolArray', true, true]])),
         normalizeQuery,
         createValidateHandler(req => [
           Object.keys(req.query as any).length ? validateOrReject(Object.assign(new Validators.Query(), req.query as any), validatorOptions) : null
@@ -356,7 +356,7 @@ export default (fastify: FastifyInstance, options: FrourioOptions = {}) => {
     {
       onRequest: hooks0.onRequest,
       preParsing: hooks0.preParsing,
-      preValidation: callParserIfExistsQuery(parseNumberTypeQueryParams([['limit', true, false]]))
+      preValidation: callParserIfExistsQuery(fastify, parseNumberTypeQueryParams([['limit', true, false]]))
     },
     methodToHandler(controller4.get)
   )

--- a/src/buildServerFile.ts
+++ b/src/buildServerFile.ts
@@ -185,8 +185,8 @@ const parseBooleanTypeQueryParams = (booleanTypeParams: [string, boolean, boolea
     }${
       hasOptionalQuery
         ? `
-const callParserIfExistsQuery = (parser: preValidationHookHandler): preValidationHookHandler => (req, reply, done) =>
-  Object.keys(req.query as any).length ? parser(req, reply, done) : done()
+const callParserIfExistsQuery = (fastify: FastifyInstance, parser: preValidationHookHandler): preValidationHookHandler => (req, reply, done) =>
+  Object.keys(req.query as any).length ? parser.bind(fastify)(req, reply, done) : done()
 `
         : ''
     }${

--- a/src/createControllersText.ts
+++ b/src/createControllersText.ts
@@ -421,7 +421,7 @@ export default (appDir: string, project: string) => {
                         ? query?.declarations.some(
                             d => d.getChildAt(1).kind === ts.SyntaxKind.QuestionToken
                           )
-                          ? `callParserIfExistsQuery(parseNumberTypeQueryParams([${numberTypeQueryParams.join(
+                          ? `callParserIfExistsQuery(fastify, parseNumberTypeQueryParams([${numberTypeQueryParams.join(
                               ', '
                             )}]))`
                           : `parseNumberTypeQueryParams([${numberTypeQueryParams.join(', ')}])`
@@ -430,7 +430,7 @@ export default (appDir: string, project: string) => {
                         ? query?.declarations.some(
                             d => d.getChildAt(1).kind === ts.SyntaxKind.QuestionToken
                           )
-                          ? `callParserIfExistsQuery(parseBooleanTypeQueryParams([${booleanTypeQueryParams.join(
+                          ? `callParserIfExistsQuery(fastify, parseBooleanTypeQueryParams([${booleanTypeQueryParams.join(
                               ', '
                             )}]))`
                           : `parseBooleanTypeQueryParams([${booleanTypeQueryParams.join(', ')}])`


### PR DESCRIPTION
## Types of changes

What kind of change does this PR introduce? (check at least one)

<!-- Update "[ ]" to "[x]" to check a box. -->

- [ ] Breaking change
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Description
[Fastify側の修正](https://github.com/fastify/fastify/pull/3143)で`this`の型のチェックが追加されました。そのため、[ここ](https://github.com/frouriojs/frourio/blob/master/servers/all/%24server.ts#L181-L182)で型エラーが発生するようになりました。

```
TS2684: The 'this' context of type 'void' is not assignable to method's 'this' of type 'FastifyInstance<Server, IncomingMessage, ServerResponse, FastifyLoggerInstance>'.
```

<!-- link to a relevant issue. -->

Issue Number: https://github.com/frouriojs/frourio/issues/172, https://github.com/frouriojs/frourio/issues/173

<!--- Describe your changes in detail. -->
期待されている`this`を指定するように修正しました。