### PR TITLE
remove managed files when the routed path is removed

### DIFF
--- a/src/cleanAllStaleRoutes.ts
+++ b/src/cleanAllStaleRoutes.ts
@@ -3,13 +3,13 @@ import path from 'path'
 import { cleanStaleRouteDir, isStaleRouteDir } from './cleanStaleRoutes'
 
 export default (dir: string): void => {
-  const dfs = (dir: string) => {
+  const dfs = (dir: string, root: boolean) => {
     fs.readdirSync(dir, { withFileTypes: true }).forEach(entry => {
-      if (entry.isDirectory()) dfs(path.resolve(dir, entry.name))
+      if (entry.isDirectory()) dfs(path.resolve(dir, entry.name), false)
     })
-    if (isStaleRouteDir(dir)) {
+    if (!root && isStaleRouteDir(dir)) {
       cleanStaleRouteDir(dir)
     }
   }
-  dfs(path.resolve(dir, 'api'))
+  dfs(path.resolve(dir, 'api'), true)
 }

--- a/src/cleanAllStaleRoutes.ts
+++ b/src/cleanAllStaleRoutes.ts
@@ -1,0 +1,15 @@
+import fs from 'fs'
+import path from 'path'
+import { cleanStaleRouteDir, isStaleRouteDir } from './cleanStaleRoutes'
+
+export default (dir: string): void => {
+  const dfs = (dir: string) => {
+    fs.readdirSync(dir, { withFileTypes: true }).forEach(entry => {
+      if (entry.isDirectory()) dfs(path.resolve(dir, entry.name))
+    })
+    if (isStaleRouteDir(dir)) {
+      cleanStaleRouteDir(dir)
+    }
+  }
+  dfs(path.resolve(dir, 'api'))
+}

--- a/src/cleanStaleRoutes.ts
+++ b/src/cleanStaleRoutes.ts
@@ -5,7 +5,7 @@ const isManagedJSTSFile = (filepath: string): boolean => {
   return Boolean(filepath.match(/^\$.*\.[mc]?[jt]s$/))
 }
 
-const isStale = (routeDir: string): boolean => {
+export const isStaleRouteDir = (routeDir: string): boolean => {
   try {
     const entries = fs.readdirSync(routeDir, { withFileTypes: true })
     if (entries.length === 0) return false
@@ -19,7 +19,7 @@ const isStale = (routeDir: string): boolean => {
   }
 }
 
-const cleanStaleRouteDir = (routeDir: string) => {
+export const cleanStaleRouteDir = (routeDir: string) => {
   try {
     const entries = fs.readdirSync(routeDir, { withFileTypes: true })
     if (entries.length === 0) return
@@ -36,7 +36,7 @@ export default (dir: string, event: string, file: string): void => {
   if (event !== 'unlink' && event !== 'unlinkDir') return
   const routeDir = path.dirname(path.resolve(dir, file))
 
-  if (isStale(routeDir)) {
+  if (isStaleRouteDir(routeDir)) {
     cleanStaleRouteDir(routeDir)
   }
 }

--- a/src/cleanStaleRoutes.ts
+++ b/src/cleanStaleRoutes.ts
@@ -1,0 +1,42 @@
+import fs from 'fs'
+import path from 'path'
+
+const isManagedJSTSFile = (filepath: string): boolean => {
+  return Boolean(filepath.match(/^\$.*\.[mc]?[jt]s$/))
+}
+
+const isStale = (routeDir: string): boolean => {
+  try {
+    const entries = fs.readdirSync(routeDir, { withFileTypes: true })
+    if (entries.length === 0) return false
+    for (const p of entries) {
+      if (p.isDirectory()) return false
+      if (!isManagedJSTSFile(p.name)) return false
+    }
+    return true
+  } catch (e: unknown) {
+    return false
+  }
+}
+
+const cleanStaleRouteDir = (routeDir: string) => {
+  try {
+    const entries = fs.readdirSync(routeDir, { withFileTypes: true })
+    if (entries.length === 0) return
+    for (const p of entries) {
+      if (p.isDirectory()) return
+      if (!isManagedJSTSFile(p.name)) return
+      fs.unlinkSync(path.resolve(routeDir, p.name))
+    }
+    fs.rmdirSync(routeDir)
+  } catch (e: unknown) {}
+}
+
+export default (dir: string, event: string, file: string): void => {
+  if (event !== 'unlink' && event !== 'unlinkDir') return
+  const routeDir = path.dirname(path.resolve(dir, file))
+
+  if (isStale(routeDir)) {
+    cleanStaleRouteDir(routeDir)
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import write from 'aspida/dist/writeRouteFile'
 import watch from 'aspida/dist/watchInputDir'
 import build from './buildServerFile'
 import clean from './cleanStaleRoutes'
+import cleanAll from './cleanAllStaleRoutes'
 
 export const run = (args: string[]) => {
   const argv = minimist(args, {
@@ -10,6 +11,8 @@ export const run = (args: string[]) => {
     alias: { v: 'version', w: 'watch', p: 'project' }
   })
   const dir = '.'
+
+  cleanAll(dir)
 
   // eslint-disable-next-line no-unused-expressions
   argv.version !== undefined

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import minimist from 'minimist'
 import write from 'aspida/dist/writeRouteFile'
 import watch from 'aspida/dist/watchInputDir'
 import build from './buildServerFile'
+import clean from './cleanStaleRoutes'
 
 export const run = (args: string[]) => {
   const argv = minimist(args, {
@@ -14,6 +15,10 @@ export const run = (args: string[]) => {
   argv.version !== undefined
     ? console.log(`v${require('../package.json').version}`)
     : argv.watch !== undefined
-    ? (write(build(dir, argv.project)), watch(dir, () => write(build(dir, argv.project))))
+    ? (write(build(dir, argv.project)),
+      watch(dir, (event, file) => {
+        clean(dir, event, file)
+        write(build(dir, argv.project))
+      }))
     : write(build(dir, argv.project))
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,16 +12,17 @@ export const run = (args: string[]) => {
   })
   const dir = '.'
 
-  cleanAll(dir)
-
-  // eslint-disable-next-line no-unused-expressions
-  argv.version !== undefined
-    ? console.log(`v${require('../package.json').version}`)
-    : argv.watch !== undefined
-    ? (write(build(dir, argv.project)),
-      watch(dir, (event, file) => {
-        clean(dir, event, file)
-        write(build(dir, argv.project))
-      }))
-    : write(build(dir, argv.project))
+  if (argv.version !== undefined) {
+    console.log(`v${require('../package.json').version}`)
+  } else if (argv.watch !== undefined) {
+    cleanAll(dir)
+    write(build(dir, argv.project))
+    watch(dir, (event, file) => {
+      clean(dir, event, file)
+      write(build(dir, argv.project))
+    })
+  } else {
+    cleanAll(dir)
+    write(build(dir, argv.project))
+  }
 }


### PR DESCRIPTION
## Types of changes

What kind of change does this PR introduce? (check at least one)

<!-- Update "[ ]" to "[x]" to check a box. -->

- [ ] Breaking change
- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactoring
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Description

<!-- link to a relevant issue. -->
多分 feat ですかね。

Issue Number: resolves https://github.com/frouriojs/frourio/issues/184

<!--- Describe your changes in detail. -->

- `$*.ts` のみが残っていたら、`$` から始まるファイルは自動生成されるとして、事前に削除
- stale チェック中に生成してしまわないようにすべて sync で処理。 (frourio dev 二重起動には耐えられない)
- すぐにディレクトリごと削除はせずに `$*.ts` のみの削除をしてディレクトリがから出ない場合に失敗する、rmdirSync を実行する
  - `$*.ts` が自動生成である限り、タイミングが悪いなどの事故は起きない
- `$a.ts/` のようなディレクトリがあるかもしれないので、ディレクトリチェックを入れている
- `$*.ts` の他に、mts, cts, js, mjs, cjs を自動生成としてみなす対象としている
  - `$*` でもいいかもしれない

## screencast

![](https://user-images.githubusercontent.com/29811106/149841893-687f48a0-a8fb-46ff-8713-5d9659f47b15.gif)

