### PR TITLE
feat(validation): add `replaceWithInstance` option

### DIFF
--- a/servers/all/api/controller.ts
+++ b/servers/all/api/controller.ts
@@ -68,7 +68,13 @@ export default defineController(
     post: v => ({
       // @ts-expect-error
       status: 200,
-      body: { id: +v.query.id, port: v.body.port, fileName: v.body.file.filename }
+      body: {
+        id: +v.query.id,
+        port: v.body.port,
+        title: v.body.title,
+        fileName: v.body.file.filename,
+        _bodyType: String(v.body)
+      }
     })
   })
 )

--- a/servers/all/api/index.ts
+++ b/servers/all/api/index.ts
@@ -15,7 +15,10 @@ export type Methods = {
     resBody: {
       id: number
       port: string
+      title: string
       fileName: string
+      /** only for testing purpose */
+      _bodyType: string
     }
   }
 }

--- a/servers/all/validators/index.ts
+++ b/servers/all/validators/index.ts
@@ -1,4 +1,4 @@
-import { Type } from 'class-transformer'
+import { Transform, Type } from 'class-transformer'
 import {
   IsNumberString,
   IsBooleanString,
@@ -52,6 +52,12 @@ export class Query {
 export class Body {
   @IsPort()
   port: string
+
+  // `@Type` decorator is required to cast `title` to a string so that the `trim()` method is not called on a non-string value
+  @IsString()
+  @Type(() => String)
+  @Transform(({ value }) => value.trim(), { toClassOnly: true })
+  title: string
 
   file: File | ReadStream
 }

--- a/src/createControllersText.ts
+++ b/src/createControllersText.ts
@@ -481,9 +481,9 @@ ${validateInfo
     v.type
       ? `          ${
           v.hasQuestion ? `Object.keys(req.${v.name} as any).length ? ` : ''
-        }validateOrReject(plainToInstance(Validators.${checker.typeToString(v.type)}, req.${
+        }transformAndValidate(Validators.${checker.typeToString(v.type)}, req.${
           v.name
-        } as any, transformerOptions), validatorOptions)${v.hasQuestion ? ' : null' : ''}`
+        } as any, (instance) => { req.${v.name} = instance })${v.hasQuestion ? ' : null' : ''}`
       : ''
   )
   .join(',\n')}\n        ])`


### PR DESCRIPTION
<!--

Thank you for your contribution! 👍

-->

## Types of changes

- [ ] Bug fixes
- [x] Features
- [ ] Maintenance
- [ ] Documentation

## Changes

frourioのグローバルオプションに`replaceWithInstance`を追加しました
これに`true`を指定すると、既存のリクエストボディ(`res.body`)やクエリ(`res.query`)をプレーンオブジェクトから`class-transformer`によって変換されたインスタンスで上書きします
既定値は`false`であり、既存のコードベースの動作は変わらない（はず）です

## Additional context

`class-transformer`には`@Transform`デコレータというものがあり、これを用いるとプロパティに対して[追加の処理を行う](https://github.com/typestack/class-transformer#additional-data-transformation)ことができます

これを用いると、例えば先頭と末尾の空白を除去するといった処理をバリデーションの段階で自動で行えます
現行のfrourioでは変換後のインスタンスを検証にのみ用いていますが、ユーザーがこれを使用できるようにすることで、ユーザーが`@Transform`デコレータの恩恵を受けられるようにします

```ts
export class Body {
  @IsString()
  @Type(() => String)
  @Transform(({ value }) => value.trim(), { toClassOnly: true })
  title: string
}
```

---

オブプションや変数の名称、テストの記述あたりにあまり自信がないので、改善点があればお教えいただけると幸いです

## Community note

<!-- Please keep this section. -->

Please upvote with reacting as :+1: to express your agreement.
